### PR TITLE
Add current week initialization in GameList component

### DIFF
--- a/analytics-queries.sql
+++ b/analytics-queries.sql
@@ -1,0 +1,164 @@
+-- ============================================
+-- NFL Pick'em Analytics Queries
+-- ============================================
+
+-- 1. Who picks the most underdogs?
+-- This query identifies users who pick underdogs most frequently.
+-- An underdog is determined by the betting spread:
+--   - If spread_team has positive spread, they are the underdog
+--   - If spread_team has negative spread, the other team is the underdog
+-- Note: Uses PostgreSQL FILTER clause. For H2/MySQL compatibility, see alternative below.
+WITH user_pick_stats AS (
+    SELECT 
+        u.id as user_id,
+        u.username,
+        u.name,
+        COUNT(*) FILTER (WHERE 
+            bo.spread IS NOT NULL AND (
+                (bo.spread > 0 AND p.picked_team = bo.spread_team)
+                OR
+                (bo.spread < 0 AND p.picked_team != bo.spread_team)
+            )
+        ) as underdog_picks,
+        COUNT(*) FILTER (WHERE bo.spread IS NOT NULL) as total_picks_with_odds
+    FROM pick p
+    JOIN app_user u ON p.user_id = u.id
+    JOIN game g ON p.game_id = g.id
+    LEFT JOIN betting_odds bo ON g.id = bo.game_id 
+        AND bo.odds_type = 'american'
+        AND bo.id = (
+            SELECT id 
+            FROM betting_odds 
+            WHERE game_id = g.id 
+            AND odds_type = 'american'
+            ORDER BY last_updated DESC 
+            LIMIT 1
+        )
+    GROUP BY u.id, u.username, u.name
+)
+SELECT 
+    username,
+    name,
+    underdog_picks,
+    total_picks_with_odds,
+    ROUND(underdog_picks * 100.0 / NULLIF(total_picks_with_odds, 0), 2) as underdog_pick_percentage
+FROM user_pick_stats
+WHERE total_picks_with_odds > 0
+ORDER BY underdog_picks DESC;
+
+-- Alternative version using CASE WHEN for broader database compatibility:
+-- WITH user_pick_stats AS (
+--     SELECT 
+--         u.id as user_id,
+--         u.username,
+--         u.name,
+--         SUM(CASE WHEN 
+--             bo.spread IS NOT NULL AND (
+--                 (bo.spread > 0 AND p.picked_team = bo.spread_team)
+--                 OR
+--                 (bo.spread < 0 AND p.picked_team != bo.spread_team)
+--             ) THEN 1 ELSE 0 END) as underdog_picks,
+--         SUM(CASE WHEN bo.spread IS NOT NULL THEN 1 ELSE 0 END) as total_picks_with_odds
+--     FROM pick p
+--     JOIN app_user u ON p.user_id = u.id
+--     JOIN game g ON p.game_id = g.id
+--     LEFT JOIN betting_odds bo ON g.id = bo.game_id 
+--         AND bo.odds_type = 'american'
+--         AND bo.id = (
+--             SELECT id 
+--             FROM betting_odds 
+--             WHERE game_id = g.id 
+--             AND odds_type = 'american'
+--             ORDER BY last_updated DESC 
+--             LIMIT 1
+--         )
+--     GROUP BY u.id, u.username, u.name
+-- )
+-- SELECT 
+--     username,
+--     name,
+--     underdog_picks,
+--     total_picks_with_odds,
+--     ROUND(underdog_picks * 100.0 / NULLIF(total_picks_with_odds, 0), 2) as underdog_pick_percentage
+-- FROM user_pick_stats
+-- WHERE total_picks_with_odds > 0
+-- ORDER BY underdog_picks DESC;
+
+
+-- ============================================
+-- 2. Most picked team by each user
+-- ============================================
+SELECT 
+    u.username,
+    u.name,
+    p.picked_team as team,
+    COUNT(*) as pick_count,
+    ROUND(COUNT(*) * 100.0 / NULLIF(SUM(COUNT(*)) OVER (PARTITION BY u.id), 0), 2) as percentage_of_user_picks
+FROM pick p
+JOIN app_user u ON p.user_id = u.id
+GROUP BY u.id, u.username, u.name, p.picked_team
+HAVING COUNT(*) = (
+    SELECT MAX(pick_count)
+    FROM (
+        SELECT picked_team, COUNT(*) as pick_count
+        FROM pick
+        WHERE user_id = u.id
+        GROUP BY picked_team
+    ) user_team_picks
+)
+ORDER BY u.username, pick_count DESC;
+
+
+-- ============================================
+-- 3. Who picks the most away teams?
+-- ============================================
+SELECT 
+    u.username,
+    u.name,
+    COUNT(*) as away_team_picks,
+    COUNT(DISTINCT p.game_id) as total_picks,
+    ROUND(COUNT(*) * 100.0 / NULLIF(COUNT(DISTINCT p.game_id), 0), 2) as away_pick_percentage
+FROM pick p
+JOIN app_user u ON p.user_id = u.id
+JOIN game g ON p.game_id = g.id
+WHERE p.picked_team = g.away_team
+GROUP BY u.id, u.username, u.name
+ORDER BY away_team_picks DESC;
+
+
+-- ============================================
+-- 4. Least picked team overall (by all users)
+-- ============================================
+SELECT 
+    p.picked_team as team,
+    COUNT(*) as total_picks,
+    COUNT(DISTINCT p.user_id) as unique_users_who_picked,
+    ROUND(COUNT(*) * 100.0 / NULLIF((SELECT COUNT(*) FROM pick), 0), 2) as percentage_of_all_picks
+FROM pick p
+GROUP BY p.picked_team
+ORDER BY total_picks ASC;
+
+
+-- ============================================
+-- 4b. Least picked team by each user (alternative interpretation)
+-- ============================================
+SELECT 
+    u.username,
+    u.name,
+    p.picked_team as least_picked_team,
+    COUNT(*) as pick_count,
+    ROUND(COUNT(*) * 100.0 / NULLIF(SUM(COUNT(*)) OVER (PARTITION BY u.id), 0), 2) as percentage_of_user_picks
+FROM pick p
+JOIN app_user u ON p.user_id = u.id
+GROUP BY u.id, u.username, u.name, p.picked_team
+HAVING COUNT(*) = (
+    SELECT MIN(pick_count)
+    FROM (
+        SELECT picked_team, COUNT(*) as pick_count
+        FROM pick
+        WHERE user_id = u.id
+        GROUP BY picked_team
+    ) user_team_picks
+)
+ORDER BY u.username, pick_count ASC;
+

--- a/frontend/src/components/GameList.js
+++ b/frontend/src/components/GameList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../AuthContext';
 
 const GameList = () => {
@@ -11,6 +11,7 @@ const GameList = () => {
   const [selectedGamePicks, setSelectedGamePicks] = useState({});
   const [bulkSubmitMessage, setBulkSubmitMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hasInitializedWeek, setHasInitializedWeek] = useState(false);
   const { user } = useAuth();
 
   // API base URL - will work for both development and Railway production
@@ -21,6 +22,48 @@ const GameList = () => {
     fetchUserPicks();
     fetchLeagues();
   }, []);
+
+  // Fetch current week and set as default
+  const fetchCurrentWeek = useCallback(async () => {
+    if (hasInitializedWeek) return; // Already initialized
+    
+    try {
+      const response = await fetch(`${API_BASE}/games/currentWeek`);
+      if (response.ok) {
+        const weekData = await response.text();
+        const fetchedWeek = parseInt(weekData, 10);
+        // Only set selectedWeek to current week on initial load
+        // Also verify the week exists in available weeks
+        if (fetchedWeek) {
+          const availableWeeks = [...new Set(games.map(game => game.week))].sort((a, b) => a - b);
+          // If current week is available, use it; otherwise use the first available week
+          if (availableWeeks.includes(fetchedWeek)) {
+            setSelectedWeek(fetchedWeek);
+          } else if (availableWeeks.length > 0) {
+            setSelectedWeek(availableWeeks[0]);
+          }
+          setHasInitializedWeek(true);
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching current week:', error);
+      // Fallback to first available week if fetch fails
+      if (games.length > 0) {
+        const availableWeeks = [...new Set(games.map(game => game.week))].sort((a, b) => a - b);
+        if (availableWeeks.length > 0) {
+          setSelectedWeek(availableWeeks[0]);
+          setHasInitializedWeek(true);
+        }
+      }
+    }
+  }, [games, hasInitializedWeek, API_BASE]);
+
+  // Set current week as default when games are loaded
+  useEffect(() => {
+    if (games.length > 0 && !hasInitializedWeek) {
+      fetchCurrentWeek();
+    }
+  }, [games, hasInitializedWeek, fetchCurrentWeek]);
 
   // Auto-select league when leagues are loaded and user has only one
   useEffect(() => {

--- a/src/main/java/com/nflpickem/pickem/repository/BettingOddsRepository.java
+++ b/src/main/java/com/nflpickem/pickem/repository/BettingOddsRepository.java
@@ -30,6 +30,13 @@ public interface BettingOddsRepository extends JpaRepository<BettingOdds, Long> 
     @Query("SELECT bo FROM BettingOdds bo WHERE bo.lastUpdated < :cutoffTime")
     List<BettingOdds> findStaleOdds(@Param("cutoffTime") java.time.Instant cutoffTime);
     
+    /**
+     * Find stale odds only for games that are not yet completed (scored = false)
+     * This preserves odds for completed games for historical analytics
+     */
+    @Query("SELECT bo FROM BettingOdds bo WHERE bo.lastUpdated < :cutoffTime AND bo.game.scored = false")
+    List<BettingOdds> findStaleOddsForUncompletedGames(@Param("cutoffTime") java.time.Instant cutoffTime);
+    
     void deleteByGame(Game game);
     
     /**

--- a/src/main/java/com/nflpickem/pickem/service/OddsService.java
+++ b/src/main/java/com/nflpickem/pickem/service/OddsService.java
@@ -692,11 +692,15 @@ public class OddsService {
     
     /**
      * Clean up stale odds
+     * Only deletes odds for games that are not yet completed (scored = false)
+     * Preserves odds for completed games to support historical analytics
      */
     public void cleanupStaleOdds() {
         Instant cutoffTime = Instant.now().minusSeconds(updateIntervalHours * 24 * 3600); // 24 hours older than update interval
-        List<BettingOdds> staleOdds = bettingOddsRepository.findStaleOdds(cutoffTime);
+        // Only delete stale odds for uncompleted games - keep odds for completed games
+        List<BettingOdds> staleOdds = bettingOddsRepository.findStaleOddsForUncompletedGames(cutoffTime);
         bettingOddsRepository.deleteAll(staleOdds);
+        logger.info("Cleaned up {} stale odds entries (preserved odds for completed games)", staleOdds.size());
     }
     
     /**


### PR DESCRIPTION
- Introduced a new state to track week initialization and a fetchCurrentWeek function to set the default week based on the current game week.
- Updated useEffect to call fetchCurrentWeek when games are loaded, ensuring the correct week is selected on initial render.
- Enhanced error handling to fallback to the first available week if fetching the current week fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds analytics SQL queries, initializes the current week in `GameList`, and updates odds cleanup to skip completed games.
> 
> - **Analytics**:
>   - Add `analytics-queries.sql` with queries for underdog pick rates, users’ most-picked teams, away-team pick rates, and least-picked teams (overall and per user).
> - **Frontend (`frontend/src/components/GameList.js`)**:
>   - Initialize `selectedWeek` from `/games/currentWeek` on first load with `hasInitializedWeek` guard and fallbacks to available weeks.
>   - Wire up effects to fetch and set current week once games load.
> - **Backend**:
>   - Repository: add `findStaleOddsForUncompletedGames` in `BettingOddsRepository` to target stale odds only for unscored games.
>   - Service: modify `OddsService.cleanupStaleOdds()` to use the new repo method and log preserved entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f8c71bfc3d76ecbb2da77cb8646d980c1554a70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->