### PR TITLE
Refactor NFL season start date handling and game day logic

### DIFF
--- a/src/main/java/com/nflpickem/pickem/service/GameScoreService.java
+++ b/src/main/java/com/nflpickem/pickem/service/GameScoreService.java
@@ -521,21 +521,19 @@ public class GameScoreService {
     }
     
     /**
-     * Check if it's a game day (Thursday, Saturday, Sunday, or Monday during NFL season).
-     * Saturday is required for Week 18 (and occasional other late-season games).
+     * Check if it's a game day (Wed–Mon NFL slate days).
+     * Wednesday covers Kickoff (e.g. 2026 opener); Saturday covers Week 18 / late-season games.
      * Also returns true if yesterday was a game day and there are unscored games from yesterday.
      */
     public boolean isGameDay() {
         LocalDate today = LocalDate.now();
         int dayOfWeek = today.getDayOfWeek().getValue(); // 1=Monday, 7=Sunday
         
-        // Monday, Thursday, Saturday, Sunday
         if (isPrimaryGameDay(dayOfWeek)) {
             return true;
         }
         
-        // Special case: Check if yesterday was a game day and there are unscored games from yesterday
-        // Handles late finishes (Mon night → Tue, Thu night → Fri, Sat night → Sun morning)
+        // Late finishes: Wed night → Thu, Thu night → Fri, Sat night → Sun, Mon night → Tue
         LocalDate yesterday = today.minusDays(1);
         int yesterdayDayOfWeek = yesterday.getDayOfWeek().getValue();
         if (isPrimaryGameDay(yesterdayDayOfWeek)) {
@@ -557,13 +555,15 @@ public class GameScoreService {
         return false;
     }
 
+    /** Mon, Wed, Thu, Sat, Sun — covers Kickoff Wednesday and Week 18 Saturday. */
     private boolean isPrimaryGameDay(int dayOfWeek) {
-        return dayOfWeek == 1 || dayOfWeek == 4 || dayOfWeek == 6 || dayOfWeek == 7;
+        return dayOfWeek == 1 || dayOfWeek == 3 || dayOfWeek == 4 || dayOfWeek == 6 || dayOfWeek == 7;
     }
 
     private String dayName(int dayOfWeek) {
         return switch (dayOfWeek) {
             case 1 -> "Monday";
+            case 3 -> "Wednesday";
             case 4 -> "Thursday";
             case 6 -> "Saturday";
             case 7 -> "Sunday";
@@ -591,7 +591,7 @@ public class GameScoreService {
             return true;
         }
         
-        // Special case: Check for unscored games from yesterday (Mon/Thu/Sat late finishes)
+        // Special case: Check for unscored games from yesterday (Wed/Thu/Sat/Mon late finishes)
         LocalDate yesterday = today.minusDays(1);
         int yesterdayDayOfWeek = yesterday.getDayOfWeek().getValue();
         if (isPrimaryGameDay(yesterdayDayOfWeek)) {
@@ -653,7 +653,7 @@ public class GameScoreService {
     
     /**
      * Manually check and update scores for unscored games from yesterday
-     * Useful for recovering from missed Monday/Thursday/Saturday night game updates
+     * Useful for recovering from missed Wed/Thu/Sat/Mon night game updates
      */
     public int updateYesterdayScores() {
         LocalDate today = LocalDate.now();

--- a/src/main/java/com/nflpickem/pickem/service/GameService.java
+++ b/src/main/java/com/nflpickem/pickem/service/GameService.java
@@ -176,11 +176,7 @@ public class GameService {
 
     private int calculateCurrentNflWeek(int seasonYear) {
         LocalDate today = LocalDate.now(ZoneId.of("America/New_York"));
-        LocalDate septemberFirst = LocalDate.of(seasonYear, 9, 1);
-        LocalDate nflSeasonStart = septemberFirst.with(TemporalAdjusters.firstInMonth(DayOfWeek.THURSDAY));
-        if (septemberFirst.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            nflSeasonStart = septemberFirst;
-        }
+        LocalDate nflSeasonStart = seasonService.getSeasonStartDate(seasonYear);
         if (today.isBefore(nflSeasonStart)) {
             return 1;
         }

--- a/src/main/java/com/nflpickem/pickem/service/OddsService.java
+++ b/src/main/java/com/nflpickem/pickem/service/OddsService.java
@@ -44,9 +44,6 @@ public class OddsService {
     @Value("${ODDS_UPDATE_INTERVAL_HOURS}")
     private int updateIntervalHours;
     
-    @Value("${NFL_SEASON_START_DATE}")
-    private String nflSeasonStartDate;
-    
     public OddsService(BettingOddsRepository bettingOddsRepository, GameRepository gameRepository,
                        RestTemplate restTemplate, AlertService alertService, SeasonService seasonService) {
         this.bettingOddsRepository = bettingOddsRepository;
@@ -299,35 +296,7 @@ public class OddsService {
      * Can be overridden by configuration
      */
     private LocalDate calculateNflSeasonStart(int year) {
-        // Check if season start date is configured
-        if (nflSeasonStartDate != null && !nflSeasonStartDate.trim().isEmpty()) {
-            try {
-                // Remove quotes if present (common issue with environment variables)
-                String cleanDate = nflSeasonStartDate.trim().replaceAll("^\"|\"$", "");
-                LocalDate configuredStart = LocalDate.parse(cleanDate);
-                if (configuredStart.getYear() == year) {
-                    logger.debug("Using configured NFL season start date: {}", configuredStart);
-                    return configuredStart;
-                }
-            } catch (Exception e) {
-                logger.warn("Invalid NFL_SEASON_START_DATE format '{}', using calculated date: {}", nflSeasonStartDate, e.getMessage());
-            }
-        }
-        
-        // Default calculation: Labor Day is the first Monday of September
-        LocalDate septemberFirst = LocalDate.of(year, 9, 1);
-        LocalDate laborDay = septemberFirst.with(java.time.temporal.TemporalAdjusters.firstInMonth(java.time.DayOfWeek.MONDAY));
-        
-        // NFL season starts the first Thursday after Labor Day
-        LocalDate nflSeasonStart = laborDay.with(java.time.temporal.TemporalAdjusters.next(java.time.DayOfWeek.THURSDAY));
-        
-        // Special case: if Labor Day is already Thursday, season starts that day
-        if (laborDay.getDayOfWeek() == java.time.DayOfWeek.THURSDAY) {
-            nflSeasonStart = laborDay;
-        }
-        
-        logger.debug("Calculated NFL season start date for {}: {}", year, nflSeasonStart);
-        return nflSeasonStart;
+        return seasonService.getSeasonStartDate(year);
     }
     
     /**

--- a/src/main/java/com/nflpickem/pickem/service/ScheduledOddsService.java
+++ b/src/main/java/com/nflpickem/pickem/service/ScheduledOddsService.java
@@ -51,14 +51,17 @@ public class ScheduledOddsService {
     }
     
     /**
-     * Check if we're in NFL season
+     * Check if we're in (or approaching) the NFL regular season.
+     * Includes August for early slate/odds loading and through mid-January for Week 18
+     * (2026 season ends Jan 10, 2027).
      */
     private boolean isNflSeason(LocalDate date) {
         Month month = date.getMonth();
-        return month == Month.SEPTEMBER || 
+        return month == Month.AUGUST ||
+               month == Month.SEPTEMBER || 
                month == Month.OCTOBER || 
                month == Month.NOVEMBER || 
                month == Month.DECEMBER || 
-               (month == Month.JANUARY && date.getDayOfMonth() <= 7); // First week of January for playoffs
+               (month == Month.JANUARY && date.getDayOfMonth() <= 15);
     }
 }

--- a/src/main/java/com/nflpickem/pickem/service/SeasonService.java
+++ b/src/main/java/com/nflpickem/pickem/service/SeasonService.java
@@ -4,9 +4,11 @@ import com.nflpickem.pickem.repository.GameRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
@@ -43,6 +45,32 @@ public class SeasonService {
             return today.getYear();
         }
         return today.getYear() - 1;
+    }
+
+    /**
+     * Kickoff / Week 1 start date for a season year.
+     * Uses NFL_SEASON_START_DATE when it matches the requested year; otherwise
+     * falls back to the first Thursday after Labor Day.
+     */
+    public LocalDate getSeasonStartDate(int seasonYear) {
+        if (configuredSeasonStartDate != null && !configuredSeasonStartDate.trim().isEmpty()) {
+            try {
+                String cleanDate = configuredSeasonStartDate.trim().replaceAll("^\"|\"$", "");
+                LocalDate configured = LocalDate.parse(cleanDate);
+                if (configured.getYear() == seasonYear) {
+                    return configured;
+                }
+            } catch (Exception ignored) {
+                // fall through to calculated start
+            }
+        }
+
+        LocalDate septemberFirst = LocalDate.of(seasonYear, 9, 1);
+        LocalDate laborDay = septemberFirst.with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY));
+        if (laborDay.getDayOfWeek() == DayOfWeek.THURSDAY) {
+            return laborDay;
+        }
+        return laborDay.with(TemporalAdjusters.next(DayOfWeek.THURSDAY));
     }
 
     /**

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -35,3 +35,7 @@ spring.web.cors.allowed-headers=*
 
 # Alert Configuration
 ALERT_MILESTONES=100,50,25,10
+
+# NFL Season — 2026 Kickoff Wednesday Sept 9
+NFL_SEASON_WEEKS=18
+NFL_SEASON_START_DATE=2026-09-09

--- a/src/main/resources/application-railway.properties
+++ b/src/main/resources/application-railway.properties
@@ -54,8 +54,8 @@ ODDS_API_BASE_URL=https://api.the-odds-api.com/v4
 ODDS_UPDATE_INTERVAL_HOURS=6
 
 # NFL Season Configuration (optional - for accurate week calculation)
-# Format: YYYY-MM-DD (e.g., 2024-09-05 for 2024 season start)
-NFL_SEASON_START_DATE="2025-09-04"
+# Format: YYYY-MM-DD — 2026 Kickoff is Wednesday Sept 9 (Seahawks vs Patriots)
+NFL_SEASON_START_DATE=2026-09-09
 
 # Discord Configuration
 DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,8 +23,8 @@ ODDS_API_BASE_URL=https://api.the-odds-api.com/v4
 ODDS_UPDATE_INTERVAL_HOURS=6
 
 # NFL Season Configuration (optional - for accurate week calculation)
-# Format: YYYY-MM-DD (e.g., 2024-09-05 for 2024 season start)
-NFL_SEASON_START_DATE=
+# Format: YYYY-MM-DD — 2026 Kickoff Wednesday Sept 9
+NFL_SEASON_START_DATE=2026-09-09
 
 # Alert Configuration
 ALERT_MILESTONES=100,50,25,10


### PR DESCRIPTION
- Updated GameScoreService to refine game day checks, now including Wednesday as a valid game day.
- Enhanced OddsService to utilize SeasonService for determining the NFL season start date, simplifying the logic.
- Adjusted ScheduledOddsService to reflect the updated definition of NFL season, now including August for early slate loading.
- Added configuration for the 2026 NFL season start date in application properties.